### PR TITLE
Feature/エンコードした文字列のみ表示するようにする

### DIFF
--- a/js/unescape.js
+++ b/js/unescape.js
@@ -48,18 +48,20 @@
       });
     };
     function trimEncodeText(encodeText, originText) {
-        var beginIndex = 1;
+        var beginIndex = 0;
         var endIndex = -1;
-        while (originText.indexOf(encodeText.substring(0, beginIndex)) == 0) {
+        var encodeTextLength = encodeText.length;
+        var originTextLength = originText.length;
+        while (encodeText.charAt(beginIndex) == originText.charAt(beginIndex)) {
             beginIndex = beginIndex + 1;
         }
-        while (encodeText.slice(endIndex) == originText.slice(endIndex)) {
+        while (encodeText.charAt(encodeTextLength + endIndex) == originText.charAt(originTextLength + endIndex)) {
             endIndex = endIndex - 1;
         }
         if (endIndex + 1 < 0) {
-            return encodeText.slice(beginIndex - 1, endIndex + 1);
+            return encodeText.slice(beginIndex, endIndex + 1);
         } else {
-            return encodeText.substring(beginIndex - 1);
+            return encodeText.substring(beginIndex);
         }
     }
 });

--- a/js/unescape.js
+++ b/js/unescape.js
@@ -18,7 +18,7 @@
         if (text != "") {
             var encodeText = unescapeUnicode(text);
             if (encodeText != text) {
-                element.text(encodeText);
+                element.text(trimEncodeText(encodeText, text));
                 element.css("left", x);
                 element.css("top", y);
                 element.css("display", "block");
@@ -47,4 +47,19 @@
         return String.fromCharCode(parseInt(m1, 16));
       });
     };
+    function trimEncodeText(encodeText, originText) {
+        var beginIndex = 1;
+        var endIndex = -1;
+        while (originText.indexOf(encodeText.substring(0, beginIndex)) == 0) {
+            beginIndex = beginIndex + 1;
+        }
+        while (encodeText.slice(endIndex) == originText.slice(endIndex)) {
+            endIndex = endIndex - 1;
+        }
+        if (endIndex + 1 < 0) {
+            return encodeText.slice(beginIndex - 1, endIndex + 1);
+        } else {
+            return encodeText.substring(beginIndex - 1);
+        }
+    }
 });


### PR DESCRIPTION
本拡張機能は要素内に含まれる文字列をデコードして
その文字列が元と違う場合にデコード文字列を表示する

なのでデコードされる文字列が通常の文字列に挟まれていると
通常の文字列まで表示されてしまって凄く長くなる

しかしデコードされて変化した文字列のみ表示すればマシになるはずなので
先頭と末尾から見ていって同じ文字は削るように変更した

ただし入れ子は削れない むしろ削らない方がいい気もするのでこのままで